### PR TITLE
Add Sphinx docs and deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install '.[dev]'
+      - name: Build documentation
+        run: |
+          cd docs
+          make html
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 aspis.egg-info/
 
 .DS_Store
+docs/build/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
 # Aspis
 
-My take on a good functional library in Python.
+Aspis is a small functional programming toolkit for Python.  It provides
+common helpers such as `curry`, `compose` and `pipe` that make it easier to
+build declarative data pipelines.
+
+Documentation for all modules is available on the project website.  The site is
+generated from the package's docstrings using Sphinx.
+
+### Building the documentation locally
+
+```bash
+cd docs
+make html
+```
+
+The resulting site will be available in `docs/build/html`.
+
+### Installation
+
+```bash
+pip install aspis
+```
+
+### Running the tests
+
+```bash
+pytest
+```
 
 ## License
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/aspis.common.rst
+++ b/docs/source/aspis.common.rst
@@ -1,0 +1,205 @@
+aspis.common package
+====================
+
+Submodules
+----------
+
+aspis.common.add module
+-----------------------
+
+.. automodule:: aspis.common.add
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.add\_index module
+------------------------------
+
+.. automodule:: aspis.common.add_index
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.add\_index\_right module
+-------------------------------------
+
+.. automodule:: aspis.common.add_index_right
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.adjust module
+--------------------------
+
+.. automodule:: aspis.common.adjust
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.all module
+-----------------------
+
+.. automodule:: aspis.common.all
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.all\_pass module
+-----------------------------
+
+.. automodule:: aspis.common.all_pass
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.always module
+--------------------------
+
+.. automodule:: aspis.common.always
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.any module
+-----------------------
+
+.. automodule:: aspis.common.any
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.any\_pass module
+-----------------------------
+
+.. automodule:: aspis.common.any_pass
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.aperture module
+----------------------------
+
+.. automodule:: aspis.common.aperture
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.apply module
+-------------------------
+
+.. automodule:: aspis.common.apply
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.apply\_spec module
+-------------------------------
+
+.. automodule:: aspis.common.apply_spec
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.apply\_to module
+-----------------------------
+
+.. automodule:: aspis.common.apply_to
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.assoc module
+-------------------------
+
+.. automodule:: aspis.common.assoc
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.compose module
+---------------------------
+
+.. automodule:: aspis.common.compose
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.curry module
+-------------------------
+
+.. automodule:: aspis.common.curry
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.divide module
+--------------------------
+
+.. automodule:: aspis.common.divide
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.equals module
+--------------------------
+
+.. automodule:: aspis.common.equals
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.flip module
+------------------------
+
+.. automodule:: aspis.common.flip
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.identity module
+----------------------------
+
+.. automodule:: aspis.common.identity
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.multiply module
+----------------------------
+
+.. automodule:: aspis.common.multiply
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.pipe module
+------------------------
+
+.. automodule:: aspis.common.pipe
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.prop module
+------------------------
+
+.. automodule:: aspis.common.prop
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.common.prop\_eq module
+----------------------------
+
+.. automodule:: aspis.common.prop_eq
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: aspis.common
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/aspis.internal.errors.rst
+++ b/docs/source/aspis.internal.errors.rst
@@ -1,0 +1,21 @@
+aspis.internal.errors package
+=============================
+
+Submodules
+----------
+
+aspis.internal.errors.arity\_error module
+-----------------------------------------
+
+.. automodule:: aspis.internal.errors.arity_error
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: aspis.internal.errors
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/aspis.internal.rst
+++ b/docs/source/aspis.internal.rst
@@ -1,0 +1,37 @@
+aspis.internal package
+======================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   aspis.internal.errors
+
+Submodules
+----------
+
+aspis.internal.eager\_partial module
+------------------------------------
+
+.. automodule:: aspis.internal.eager_partial
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+aspis.internal.utils module
+---------------------------
+
+.. automodule:: aspis.internal.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: aspis.internal
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/aspis.rst
+++ b/docs/source/aspis.rst
@@ -1,0 +1,19 @@
+aspis package
+=============
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   aspis.common
+   aspis.internal
+
+Module contents
+---------------
+
+.. automodule:: aspis
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,39 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Aspis'
+copyright = '2025, BriHan-Tech'
+author = 'BriHan-Tech'
+
+version = '0.3.0'
+release = '0.3.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../..'))
+
+# Use Read the Docs theme for a cleaner look
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,18 @@
+.. Aspis documentation master file, created by
+   sphinx-quickstart on Tue Jul  1 10:06:44 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Aspis documentation
+===================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+aspis
+=====
+
+.. toctree::
+   :maxdepth: 4
+
+   aspis


### PR DESCRIPTION
## Summary
- expand README with install and docs instructions
- generate Sphinx documentation site
- ignore generated documentation build dir
- add workflow to deploy docs from main branch using GitHub Pages

## Testing
- `pytest -q`
- `cd docs && make html`

------
https://chatgpt.com/codex/tasks/task_e_6863b2ed102c8330a38c2692b3473cc6